### PR TITLE
Build smaller

### DIFF
--- a/aegisthus-core/src/main/java/com/netflix/aegisthus/tools/AegisthusSerializer.java
+++ b/aegisthus-core/src/main/java/com/netflix/aegisthus/tools/AegisthusSerializer.java
@@ -22,11 +22,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.pig.data.DataByteArray;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 
 /**
  * Read and write Aegisthus Json format.
@@ -39,7 +40,6 @@ public class AegisthusSerializer {
 
 	static {
 		jsonFactory.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
-		jsonFactory.configure(JsonParser.Feature.INTERN_FIELD_NAMES, false);
 	}
 
 	public Object type(String value) {

--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,11 @@ project(':aegisthus-core') {
     apply plugin: 'eclipse'
     dependencies {
         includeInJar 'com.google.guava:guava:12.0'
+        includeInJar 'com.fasterxml.jackson.core:jackson-core:2.1.4'
+        includeInJar 'com.fasterxml.jackson.core:jackson-annotations:2.1.4'
+        includeInJar 'com.fasterxml.jackson.core:jackson-databind:2.1.4'
         compile 'org.apache.pig:pig:0.11.1'
         compile 'org.slf4j:slf4j-api:1.6.3'
-        compile 'org.codehaus.jackson:jackson-mapper-asl:1.8.9'
         compile 'org.apache.hadoop:hadoop-core:' + (project.hasProperty('hadoopVersion') ? hadoopVersion : '1.1.0')
         configurations.compile.extendsFrom(configurations.includeInJar)
     }
@@ -58,6 +60,7 @@ project(':aegisthus-hadoop') {
         }
         includeInJar project(':aegisthus-core')
         includeInJar 'org.apache.cassandra:cassandra-all:1.1.8'
+
 
         compile 'org.slf4j:slf4j-api:1.6.3'
         compile 'org.apache.hadoop:hadoop-core:' + (project.hasProperty('hadoopVersion') ? hadoopVersion : '1.1.0')


### PR DESCRIPTION
Basically create a much smaller jar including only what we currently need outside of hadoop proper.  This still includes Pig as a dependency for hadoop, but that can be readdressed in refactoring the dataflow in future.
